### PR TITLE
Set defer to false, to always load the service provider

### DIFF
--- a/src/RedisSentinel/Laravel/RedisSentinelServiceProvider.php
+++ b/src/RedisSentinel/Laravel/RedisSentinelServiceProvider.php
@@ -12,7 +12,7 @@ class RedisSentinelServiceProvider extends ServiceProvider
      *
      * @var bool
      */
-    protected $defer = true;
+    protected $defer = false;
 
     /**
      * Add the connector to the queue drivers


### PR DESCRIPTION
The service provider does not get loaded when running `php artisan queue:listen sentinel` otherwise